### PR TITLE
Remove the Null type bound from `CoregexInstances#Matching`

### DIFF
--- a/scalacheck/src/main/scala/com/github/simy4/coregex/scalacheck/CoregexInstances.scala
+++ b/scalacheck/src/main/scala/com/github/simy4/coregex/scalacheck/CoregexInstances.scala
@@ -23,17 +23,17 @@ import org.scalacheck.{ Arbitrary, Gen, Shrink }
 import java.util.regex.Pattern
 
 trait CoregexInstances {
-  type Matching[A >: Null <: String, Regex >: Null <: String with Singleton] <: A
+  type Matching[A <: String, Regex <: String with Singleton] <: A
 
   implicit def arbitraryInputStringMatchingRegexStringWithSingleton[
-    A >: Null <: String,
-    Regex >: Null <: String with Singleton
+    A <: String,
+    Regex <: String with Singleton
   ](implicit regex: ValueOf[Regex]): Arbitrary[Matching[A, Regex]] =
     Arbitrary(CoregexGen.fromPattern(Pattern.compile(regex.value)).asInstanceOf[Gen[Matching[A, Regex]]])
 
   implicit def shrinkInputStringMatchingRegexStringWithSingleton[
-    A >: Null <: String,
-    Regex >: Null <: String with Singleton
+    A <: String,
+    Regex <: String with Singleton
   ](implicit regex: ValueOf[Regex]): Shrink[Matching[A, Regex]] = {
     val coregex = CoregexParser.getInstance().parse(Pattern.compile(regex.value))
     Shrink.withLazyList { larger =>


### PR DESCRIPTION
After merging https://github.com/lampepfl/dotty/pull/17470 in 3.4.x and running Open Community Build we found out it is no longer compiling - [build logs](https://github.com/VirtusLab/community-build3/actions/runs/5836591202/job/15831389198). However, the compiler team has decided that that reason for that is not a new regression, but rather typer improvement. 
This change does not affect the Scala 3 LTS line (3.3.x) but would affect the users of Scala 3.4.x and later.

To allow for further testing this project in the Open Community Build and in the future to allow users of Scala 3.4.x to use this library I propose a temporary workaround which removes the unnecessary Null type bound.