### PR TITLE
Exclude vulnerable JUnit version from compile dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,8 +78,7 @@ lazy val functionaljavaQuickcheck = (project in file("functionaljava-quickcheck"
     description   := "Functionaljava quickcheck bindings for coregex library.",
     headerEndYear := Some(2025),
     libraryDependencies ++= Seq(
-      "org.functionaljava" % "functionaljava-quickcheck" % "5.0"    % Provided,
-      "junit"              % "junit"                     % "4.13.2" % Test,
+      "org.functionaljava" % "functionaljava-quickcheck" % "5.0"    % Provided exclude("junit", "junit"),
       "com.github.sbt"     % "junit-interface"           % "0.13.3" % Test
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")
@@ -114,9 +113,8 @@ lazy val junitQuickcheck = (project in file("junit-quickcheck"))
     description   := "JUnit Quickcheck bindings for coregex library.",
     headerEndYear := Some(2025),
     libraryDependencies ++= Seq(
-      "com.pholser"    % "junit-quickcheck-core"       % "1.0"    % Provided,
+      "com.pholser"    % "junit-quickcheck-core"       % "1.0"    % Provided exclude("junit", "junit"),
       "com.pholser"    % "junit-quickcheck-generators" % "1.0"    % Test,
-      "junit"          % "junit"                       % "4.13.2" % Test,
       "org.slf4j"      % "slf4j-simple"                % "1.7.25" % Test,
       "com.github.sbt" % "junit-interface"             % "0.13.3" % Test
     ),


### PR DESCRIPTION
Address compile time dependency scan vulns by excluding jUnit.